### PR TITLE
fix broken links

### DIFF
--- a/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
+++ b/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
@@ -182,18 +182,18 @@ A list of paired name and value arguments for the model type. Each model type or
 Specify the task using the Unitxt recipe format:
 
 * `card`: Use the `name` to specify a Unitxt card or `custom` for a custom card
-** `name`: Specify a Unitxt card from the link:https://www.unitxt.ai/en/latest/catalog/catalog.cards.__dir__.html[Unitxt catalog]. Use the card's ID as the value.
+** `name`: Specify a Unitxt card from the link:++https://www.unitxt.ai/en/latest/catalog/catalog.cards.__dir__.html++[Unitxt catalog]. Use the card's ID as the value.
   For example: The ID of link:https://www.unitxt.ai/en/latest/catalog/catalog.cards.wnli.html[Wnli card] is `cards.wnli`.
 ** `custom`: Define a custom card and use it. The value is a JSON string for a custom Unitxt card which contains the custom dataset.
     Use the documentation link:https://www.unitxt.ai/en/latest/docs/adding_dataset.html#adding-to-the-catalog[here] to compose a custom card, store it as a JSON file, and use the JSON content as the value here.
     If the dataset used by the custom card needs an API key from an environment variable or a persistent volume, you have to
     set up corresponding resources under the `pod` field. Check the `pod` field below.
-* `template`: Specify a Unitxt template from the link:https://www.unitxt.ai/en/latest/catalog/catalog.templates.__dir__.html[Unitxt catalog]. Use the template's ID as the value.
-* `task` (optional): Specify a Unitxt task from the link:https://www.unitxt.ai/en/latest/catalog/catalog.cards.__dir__.html[Unitxt catalog]. Use the task's ID as the value.
+* `template`: Specify a Unitxt template from the link:++https://www.unitxt.ai/en/latest/catalog/catalog.templates.__dir__.html++[Unitxt catalog]. Use the template's ID as the value.
+* `task` (optional): Specify a Unitxt task from the link:++https://www.unitxt.ai/en/latest/catalog/catalog.cards.__dir__.html++[Unitxt catalog]. Use the task's ID as the value.
   A Unitxt card has a pre-defined task. Only specify a value for this if you want to run different task.
-* `metrics` (optional): Specify a list of Unitx metrics from the link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.__dir__.html[Unitxt catalog]. Use the metric's ID as the value.
+* `metrics` (optional): Specify a list of Unitx metrics from the link:++https://www.unitxt.ai/en/latest/catalog/catalog.metrics.__dir__.html++[Unitxt catalog]. Use the metric's ID as the value.
   A Unitxt task has a set of pre-defined metrics. Only specify a set of metrics if you need different metrics.
-* `format` (optional): Specify a Unitxt format from the link:https://www.unitxt.ai/en/latest/catalog/catalog.formats.__dir__.html[Unitxt catalog]. Use the format's ID as the value.
+* `format` (optional): Specify a Unitxt format from the link:++https://www.unitxt.ai/en/latest/catalog/catalog.formats.__dir__.html++[Unitxt catalog]. Use the format's ID as the value.
 * `loaderLimit` (optional): Specifies the maximum number of instances per stream to be returned from the loader (used to reduce loading time in large datasets).
 * `numDemos` (optional): Number of fewshot to be used.
 * `demosPoolSize` (optional): Size of the fewshot pool.


### PR DESCRIPTION
some links contain `_` characters and cause the markup parser interprets, and become invalid URLs.
Use the `++` to escape the markup parser interpretation.