### PR TITLE
Update lm-eval-tutorial.adoc

### DIFF
--- a/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
+++ b/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
@@ -709,7 +709,7 @@ spec:
     taskNames:
       - mmlu
   logSamples: true
-  batchSize: 1
+  batchSize: '1'
   modelArgs:
     - name: model
       value: granite


### PR DESCRIPTION
wrong spec validation:

https://github.com/trustyai-explainability/trustyai-service-operator/blob/b2f471ddbd45165b57310c4fe1b9bf563ee3bdf6/api/lmes/v1alpha1/lmevaljob_types.go#L513

<img width="690" alt="image" src="https://github.com/user-attachments/assets/a502ba14-6504-4164-8c1a-ce1b5f0686d5" />

after:

<img width="396" alt="image" src="https://github.com/user-attachments/assets/802ee262-d7cd-48be-be51-dcffbf573626" />

OK.

cc @ruivieira 