### PR TITLE
fix: escape _ in hyperlink to avoid

### DIFF
--- a/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
+++ b/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
@@ -780,7 +780,7 @@ spec:
         value: <HF_TOKEN>
 ----
 
-There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.__dir__.html[LLMaaJ metrics] available in the Unitxt catalog.
+There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.\_\_dir\_\_.html[LLMaaJ metrics] available in the Unitxt catalog.
 
 
 === Using PVCs as storage


### PR DESCRIPTION
__dir__ becoming <em>dir</em> in Antora/asciidoc