### PR TITLE
fix: bis, proper escape; local build with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install
+install:
+	npm install
+
+.PHONY: build
+build: install
+	npx antora antora-playbook.yml
+
+.PHONY: build-local
+build-local: install
+	yq '.content.sources[0].branches = ["HEAD"]' antora-playbook.yml > antora-temp.yml
+	npx antora antora-temp.yml
+	rm antora-temp.yml

--- a/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
+++ b/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
@@ -780,7 +780,7 @@ spec:
         value: <HF_TOKEN>
 ----
 
-There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.__dir__.html[LLMaaJ metrics] available in the Unitxt catalog.
+There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.\_\_dir\_\_.html[LLMaaJ metrics] available in the Unitxt catalog.
 
 
 === Using PVCs as storage

--- a/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
+++ b/docs/modules/ROOT/pages/lm-eval-tutorial.adoc
@@ -780,7 +780,7 @@ spec:
         value: <HF_TOKEN>
 ----
 
-There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.\_\_dir\_\_.html[LLMaaJ metrics] available in the Unitxt catalog.
+There are also a handful of pre-existing link:https://www.unitxt.ai/en/latest/catalog/catalog.metrics.llm_as_judge.++__dir__++.html[LLMaaJ metrics] available in the Unitxt catalog.
 
 
 === Using PVCs as storage


### PR DESCRIPTION
sorry I've been overconfident just earlier.

Followup https://github.com/trustyai-explainability/trustyai-explainability.github.io/pull/73

this time checked also locally and "noted" for local build with Makefile 🙃 

<img width="2032" height="1192" alt="Screenshot 2025-09-11 at 14 36 08" src="https://github.com/user-attachments/assets/6e8b5ee9-5ff3-49ac-b13f-1847325abed6" />
