### PR TITLE
docs: Add LMEval TLS documentation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,6 +14,7 @@
 *** xref:saliency-explanations-on-odh.adoc[]
 *** xref:saliency-explanations-with-kserve.adoc[]
 ** xref:lm-eval-tutorial.adoc[]
+*** xref:lmeval-oauth-authentication.adoc[OAuth Authentication]
 *** xref:lm-eval-tutorial-toxicity.adoc[Toxicity Measurement]
 ** xref:gorch-tutorial.adoc[]
 *** xref:hf-serving-runtime-tutorial.adoc[Using Hugging Face models with GuardrailsOrchestrator]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 *** xref:saliency-explanations-with-kserve.adoc[]
 ** xref:lm-eval-tutorial.adoc[]
 *** xref:lmeval-oauth-authentication.adoc[OAuth Authentication]
+*** xref:lmeval-tls-certificates.adoc[TLS Certificates]
 *** xref:lm-eval-tutorial-toxicity.adoc[Toxicity Measurement]
 ** xref:gorch-tutorial.adoc[]
 *** xref:hf-serving-runtime-tutorial.adoc[Using Hugging Face models with GuardrailsOrchestrator]

--- a/docs/modules/ROOT/pages/lmeval-oauth-authentication.adoc
+++ b/docs/modules/ROOT/pages/lmeval-oauth-authentication.adoc
@@ -212,44 +212,35 @@ OAuth-protected InferenceServices typically expose:
 
 === Common Issues
 
-==== OAuth Redirect Loop
-*302 redirects to OAuth authorisation endpoint*
+[cols="1,2,2"]
+|===
+|Problem |Causes |Solution
 
-*Causes*:
-
-* Missing RBAC permissions
+|OAuth Redirect Loop +
+*(302 redirects to OAuth authorisation endpoint)*
+a|* Missing RBAC permissions
 * Invalid service account token
 * Incorrect OAuth proxy configuration
-
-*Solutions*:
-
-* Verify RBAC permissions with `kubectl auth can-i`
+a|* Verify RBAC permissions with `kubectl auth can-i`
 * Check service account token validity
 * Ensure OAuth proxy allows programmatic access
 
-==== SSL Certificate Errors
-*SSL verification failures*
-
-*Solutions*:
-
-* Set `verify_certificate: "False"` in model arguments
+|SSL Certificate Errors +
+*(SSL verification failures)*
+|SSL certificate validation issues
+a|* Set `verify_certificate: "False"` in model arguments
 * Use proper CA certificates if available
 * Verify the correct HTTPS endpoint
 
-==== Connection Refused
-*Connection refused on port 8443*
-
-*Causes*:
-
-* Incorrect service endpoint
+|Connection Refused +
+*(Connection refused on port 8443)*
+a|* Incorrect service endpoint
 * OAuth proxy not running
 * Network policies blocking access
-
-*Solutions*:
-
-* Verify InferenceService is running: `kubectl get inferenceservice`
+a|* Verify InferenceService is running: `kubectl get inferenceservice`
 * Check service endpoints: `kubectl get svc`
 * Test connectivity from within cluster
+|===
 
 === Debugging Commands
 
@@ -280,7 +271,4 @@ Check LMEvalJob logs:
 kubectl logs -n $NAMESPACE -l job-name=oauth-eval-job
 ----
 
-This guide provides a complete setup for authenticating LMEvalJob with OAuth-protected KServe InferenceServices. 
-The key components are:
-
-Following these steps ensures secure, automated evaluation of models deployed with KServe OAuth protection.
+This guide provides a complete setup for authenticating LMEvalJob with OAuth-protected KServe InferenceServices.

--- a/docs/modules/ROOT/pages/lmeval-oauth-authentication.adoc
+++ b/docs/modules/ROOT/pages/lmeval-oauth-authentication.adoc
@@ -1,0 +1,286 @@
+= LMEval Authentication with OAuth-Protected KServe InferenceServices
+:sectnums:
+:icons: font
+
+== Overview
+
+This guide explains how to configure LMEvalJob Custom Resources to authenticate with OAuth-protected KServe InferenceServices using service account tokens. When KServe InferenceServices are protected by OAuth proxy (`security.opendatahub.io/enable-auth: "true"`), they require proper authentication and RBAC permissions.
+
+== Prerequisites
+
+* OpenShift/Kubernetes cluster with KServe installed
+* TrustyAI Operator installed and LMEvalJob CRD available
+* OAuth-protected InferenceService deployed
+* `kubectl` access with sufficient permissions to create RBAC resources
+
+== Authentication Architecture
+
+When an InferenceService has OAuth protection enabled, the authentication flow works as follows:
+
+1. **OAuth Proxy**: Protects the InferenceService endpoint
+2. **Service Account Token**: Used for programmatic API access
+3. **RBAC Permissions**: Required for the service account to access InferenceServices
+4. **Subject Access Review (SAR)**: OAuth proxy validates permissions before allowing access
+
+== Step-by-Step Setup
+
+=== Step 1: Create RBAC Permissions
+
+The service account needs permission to access InferenceServices in the namespace.
+
+==== Create the Role
+
+Create `role.yaml`:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: inferenceservice-reader
+rules:
+- apiGroups: ["serving.kserve.io"]
+  resources: ["inferenceservices"]
+  verbs: ["get", "list"]  # <1>
+----
+<1> `get` and `list` permissions are required for OAuth proxy validation
+
+Apply the Role:
+
+[source,bash]
+----
+kubectl apply -f role.yaml -n $NAMESPACE
+----
+
+==== Create the RoleBinding
+
+Create `rolebinding.yaml`:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lmeval-inferenceservice-access
+subjects:
+- kind: ServiceAccount
+  name: default  # <1>
+roleRef:
+  kind: Role
+  name: inferenceservice-reader
+  apiGroup: rbac.authorization.k8s.io
+----
+<1> Using `default` service account; create a dedicated SA if needed
+
+Apply the RoleBinding:
+
+[source,bash]
+----
+kubectl apply -f rolebinding.yaml -n $NAMESPACE
+----
+
+=== Step 2: Create Service Account Token Secret
+
+Create a long-lived service account token for the LMEvalJob to use.
+
+Create `sa-token-secret.yaml`:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: lmeval-sa-token
+  annotations:
+    kubernetes.io/service-account.name: default  # <1>
+type: kubernetes.io/service-account-token
+----
+<1> Reference to the service account with RBAC permissions
+
+Apply the Secret:
+
+[source,bash]
+----
+kubectl apply -f sa-token-secret.yaml -n $NAMESPACE
+----
+
+=== Step 3: Verify RBAC Permissions
+
+Verify that the service account has the necessary permissions:
+
+[source,bash]
+----
+kubectl auth can-i get inferenceservices.serving.kserve.io \
+  -n $NAMESPACE \
+  --as=system:serviceaccount:$NAMESPACE:default
+----
+
+Expected output: `yes`
+
+=== Step 4: Configure LMEvalJob
+
+Create an LMEvalJob that uses the service account token for authentication.
+
+Create `lmeval-job.yaml`:
+
+[source,yaml]
+----
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: LMEvalJob
+metadata:
+  name: oauth-eval-job
+spec:
+  model: local-completions  # <1>
+  taskList:
+    taskNames: ["mmlu"]
+  logSamples: true
+  batchSize: "1"
+  allowOnline: true
+  allowCodeExecution: true
+  modelArgs:  # <2>
+    - name: model
+      value: granite
+    - name: base_url
+      value: $ROUTE/v1/completions  # <3>
+    - name: num_concurrent
+      value: "1"
+    - name: max_retries
+      value: "3"
+    - name: tokenized_requests
+      value: "false"
+    - name: tokenizer
+      value: ibm-granite/granite-7b-instruct
+    - name: verify_certificate
+      value: "False"  # <4>
+  pod:
+    container:
+      env:
+        - name: OPENAI_API_KEY  # <5>
+          valueFrom:
+            secretKeyRef:
+              name: lmeval-sa-token
+              key: token
+----
+<1> Use `local-completions` for OpenAI-compatible API endpoints
+<2> Model arguments configure the evaluation client
+<3> HTTPS endpoint of the OAuth-protected InferenceService
+<4> Disable SSL verification for self-signed certificates
+<5> Service account token injected as API key environment variable
+
+Apply the LMEvalJob:
+
+[source,bash]
+----
+kubectl apply -f lmeval-job.yaml -n $NAMESPACE
+----
+
+== Configuration Reference
+
+=== Required Model Arguments
+
+[cols="1,2,1"]
+|===
+|Argument |Description |Example
+
+|`model`
+|Model name for the evaluation
+|`granite`
+
+|`base_url`
+|HTTPS URL of the OAuth-protected InferenceService
+|`$ROUTE/v1/completions`
+
+|`verify_certificate`
+|Set to `"False"` for self-signed certificates
+|`"False"`
+
+|`tokenizer`
+|Tokenizer compatible with the model
+|`ibm-granite/granite-7b-instruct`
+|===
+
+=== OAuth Proxy Endpoints
+
+OAuth-protected InferenceServices typically expose:
+
+* **HTTPS Port**: `8443` (OAuth proxy)
+* **Health Check**: `/health`
+* **API Endpoint**: `/v1/completions`
+* **OAuth Callback**: `/oauth/callback`
+
+== Troubleshooting
+
+=== Common Issues
+
+==== OAuth Redirect Loop
+*302 redirects to OAuth authorisation endpoint*
+
+*Causes*:
+
+* Missing RBAC permissions
+* Invalid service account token
+* Incorrect OAuth proxy configuration
+
+*Solutions*:
+
+* Verify RBAC permissions with `kubectl auth can-i`
+* Check service account token validity
+* Ensure OAuth proxy allows programmatic access
+
+==== SSL Certificate Errors
+*SSL verification failures*
+
+*Solutions*:
+
+* Set `verify_certificate: "False"` in model arguments
+* Use proper CA certificates if available
+* Verify the correct HTTPS endpoint
+
+==== Connection Refused
+*Connection refused on port 8443*
+
+*Causes*:
+
+* Incorrect service endpoint
+* OAuth proxy not running
+* Network policies blocking access
+
+*Solutions*:
+
+* Verify InferenceService is running: `kubectl get inferenceservice`
+* Check service endpoints: `kubectl get svc`
+* Test connectivity from within cluster
+
+=== Debugging Commands
+
+Check RBAC permissions:
+[source,bash]
+----
+kubectl auth can-i get inferenceservices.serving.kserve.io \
+  -n $NAMESPACE \
+  --as=system:serviceaccount:$NAMESPACE:default
+----
+
+Verify service account token:
+[source,bash]
+----
+kubectl get secret lmeval-sa-token -n $NAMESPACE -o jsonpath='{.data.token}' | base64 -d | head -c 50
+----
+
+Test OAuth proxy connectivity:
+[source,bash]
+----
+kubectl run debug-pod --image=curlimages/curl:latest --rm -it --restart=Never -n $NAMESPACE -- \
+  sh -c "curl -k -I $ROUTE/health"
+----
+
+Check LMEvalJob logs:
+[source,bash]
+----
+kubectl logs -n $NAMESPACE -l job-name=oauth-eval-job
+----
+
+This guide provides a complete setup for authenticating LMEvalJob with OAuth-protected KServe InferenceServices. 
+The key components are:
+
+Following these steps ensures secure, automated evaluation of models deployed with KServe OAuth protection.

--- a/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
+++ b/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
@@ -82,7 +82,7 @@ Then reference this ConfigMap in your volume configuration.
 
 === Step 2: Create LMEvalJob with TLS Configuration
 
-Before creating the LMEvalJob, ensure you have created the service CA bundle ConfigMap in your target namespace using one of the methods described above.
+Before creating the LMEvalJob, make sure you have created the service CA bundle ConfigMap in your namespace using one of the methods described above.
 
 Create an LMEvalJob that mounts TLS certificates and configures SSL verification.
 

--- a/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
+++ b/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
@@ -51,7 +51,38 @@ kubectl get configmap openshift-service-ca.crt -n openshift-config-managed -o ya
 
 This contains the `service-ca.crt` key with the Certificate Authority bundle.
 
+IMPORTANT: The `openshift-service-ca.crt` ConfigMap exists in the `openshift-config-managed` namespace, but Kubernetes cannot mount ConfigMaps across namespaces. To use this CA bundle in your LMEvalJob, you have two options:
+
+1. **Copy the ConfigMap** to your target namespace:
++
+[source,bash]
+----
+kubectl get configmap openshift-service-ca.crt -n openshift-config-managed -o yaml | \
+  sed 's/namespace: openshift-config-managed/namespace: $NAMESPACE/' | \
+  kubectl apply -f -
+----
+
+2. **Use OpenShift's service CA injection** (recommended):
++
+Create a ConfigMap with the injection annotation:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-ca-bundle
+  namespace: $NAMESPACE
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data: {}  # left empty; the operator will add service-ca.crt
+----
++
+Then reference this ConfigMap in your volume configuration.
+
 === Step 2: Create LMEvalJob with TLS Configuration
+
+Before creating the LMEvalJob, ensure you have created the service CA bundle ConfigMap in your target namespace using one of the methods described above.
 
 Create an LMEvalJob that mounts TLS certificates and configures SSL verification.
 
@@ -110,7 +141,7 @@ spec:
           secretName: $MODEL-predictor-serving-cert
       - name: ca-bundle
         configMap:
-          name: openshift-service-ca.crt
+          name: service-ca-bundle
 ----
 <1> Replace `$NAMESPACE` with your target namespace
 <2> Use `local-completions` for OpenAI-compatible API endpoints
@@ -185,16 +216,32 @@ volumes:
 ----
 
 ==== CA Bundle ConfigMap Volume
+
+**Option 1: Using Service CA Injection (Recommended)**
 [source,yaml]
 ----
 volumes:
   - name: ca-bundle
     configMap:
-      name: openshift-service-ca.crt
+      name: service-ca-bundle  # <1>
       items:  # Optional: specify specific keys
         - key: service-ca.crt
           path: service-ca.crt
 ----
+<1> ConfigMap created with `service.beta.openshift.io/inject-cabundle: "true"` annotation
+
+**Option 2: Using Copied ConfigMap**
+[source,yaml]
+----
+volumes:
+  - name: ca-bundle
+    configMap:
+      name: openshift-service-ca.crt  # <1>
+      items:  # Optional: specify specific keys
+        - key: service-ca.crt
+          path: service-ca.crt
+----
+<1> ConfigMap manually copied from `openshift-config-managed` namespace
 
 ==== Volume Mount Options
 [source,yaml]
@@ -272,9 +319,11 @@ kubectl logs tls-eval-job -n $NAMESPACE | grep -i verify
 a|* Secret or configmap missing
 * Incorrect volume mount paths
 * Wrong secret/configmap names
-a|* Verify secret and configmap exist in the same namespace
+* ConfigMap in wrong namespace
+a|* Verify secret and configmap exist in the same namespace as LMEvalJob
 * Check volume mount paths and subPath values
 * Ensure correct secret/configmap names
+* Use service CA injection or copy ConfigMap to target namespace
 
 |SSL Verification Still Disabled +
 *(`InsecureRequestWarning` in logs, `verify_certificate: False` in modelArgs)*
@@ -302,4 +351,13 @@ a|* Wrong CA bundle for the certificate chain
 a|* Verify certificate validity: `openssl x509 -in /etc/ssl/certs/tls.crt -text -noout`
 * Check certificate chain matches CA bundle
 * Use correct ConfigMap for your cluster's CA
+
+|Cross-Namespace ConfigMap Error +
+*(ConfigMap `openshift-service-ca.crt` not found in target namespace)*
+a|* Trying to mount ConfigMap from `openshift-config-managed` namespace
+* Kubernetes cannot mount ConfigMaps across namespaces
+* Missing service CA injection setup
+a|* Create ConfigMap with `service.beta.openshift.io/inject-cabundle: "true"` annotation
+* Or copy ConfigMap: `kubectl get configmap openshift-service-ca.crt -n openshift-config-managed -o yaml \| sed 's/namespace: openshift-config-managed/namespace: $NAMESPACE/' \| kubectl apply -f -`
+* Update volume to reference the namespaced ConfigMap
 |===

--- a/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
+++ b/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
@@ -148,7 +148,7 @@ spec:
 <3> Model arguments configure the evaluation client
 <4> HTTPS endpoint of the OAuth-protected InferenceService
 <5> Path to mounted CA bundle for SSL verification
-<6> Service account token for OAuth authentication
+<6> Service account token for OAuth authentication (see xref:lmeval-oauth-authentication.adoc#_step_2_create_service_account_token_secret[Create Service Account Token Secret])
 <7> Mount TLS certificate and CA bundle into container
 <8> Define volumes for TLS secret and CA bundle ConfigMap
 

--- a/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
+++ b/docs/modules/ROOT/pages/lmeval-tls-certificates.adoc
@@ -1,0 +1,305 @@
+= LMEvalJob with TLS Certificates from OAuth-Protected Models
+:sectnums:
+:icons: font
+
+== Overview
+
+This guide explains how to configure LMEvalJob Custom Resources to use TLS certificates from OAuth-protected KServe InferenceServices for proper SSL verification. Instead of disabling SSL verification (`verify_certificate: "False"`), this approach mounts the actual TLS certificates and CA bundle for secure communication.
+
+== TLS Certificate Architecture
+
+When using TLS certificates with OAuth-protected InferenceServices:
+
+1. **TLS Secret**: Contains the InferenceService's TLS certificate and private key
+2. **CA Bundle ConfigMap**: Contains the Certificate Authority bundle for trust chain
+3. **Volume Mounts**: Mount certificates into the evaluation pod
+4. **SSL Verification**: Configure evaluation client to use mounted certificates
+
+== Step-by-Step Setup
+
+=== Step 1: Identify TLS Resources
+
+First, identify the TLS secret and CA bundle for your InferenceService.
+
+==== Find the TLS Secret
+
+[source,bash]
+----
+kubectl get secret -n $NAMESPACE | grep serving-cert
+----
+
+Expected output shows secrets like `$MODEL-predictor-serving-cert`.
+
+==== Examine the TLS Secret Structure
+
+[source,bash]
+----
+kubectl get secret $MODEL-predictor-serving-cert -n $NAMESPACE -o yaml
+----
+
+The secret contains:
+
+- `tls.crt`: The TLS certificate
+- `tls.key`: The private key
+
+==== Verify CA Bundle ConfigMap
+
+[source,bash]
+----
+kubectl get configmap openshift-service-ca.crt -n openshift-config-managed -o yaml
+----
+
+This contains the `service-ca.crt` key with the Certificate Authority bundle.
+
+=== Step 2: Create LMEvalJob with TLS Configuration
+
+Create an LMEvalJob that mounts TLS certificates and configures SSL verification.
+
+Create `tls-lmeval-job.yaml`:
+
+[source,yaml]
+----
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: LMEvalJob
+metadata:
+  name: tls-eval-job
+  namespace: $NAMESPACE  # <1>
+spec:
+  model: local-completions  # <2>
+  taskList:
+    taskNames: ["mmlu"]
+  logSamples: true
+  batchSize: "1"
+  allowOnline: true
+  allowCodeExecution: true
+  modelArgs:  # <3>
+    - name: model
+      value: granite
+    - name: base_url
+      value: https://$MODEL-predictor.$NAMESPACE.svc.cluster.local:8443/v1/completions  # <4>
+    - name: num_concurrent
+      value: "1"
+    - name: max_retries
+      value: "3"
+    - name: tokenized_requests
+      value: "false"
+    - name: tokenizer
+      value: ibm-granite/granite-7b-instruct
+    - name: verify_certificate
+      value: "/etc/ssl/certs/ca-bundle.crt"  # <5>
+  pod:
+    container:
+      env:
+        - name: OPENAI_API_KEY  # <6>
+          valueFrom:
+            secretKeyRef:
+              name: lmeval-sa-token
+              key: token
+      volumeMounts:  # <7>
+        - name: tls-certs
+          mountPath: /etc/ssl/certs/tls.crt
+          subPath: tls.crt
+          readOnly: true
+        - name: ca-bundle
+          mountPath: /etc/ssl/certs/ca-bundle.crt
+          subPath: service-ca.crt
+          readOnly: true
+    volumes:  # <8>
+      - name: tls-certs
+        secret:
+          secretName: $MODEL-predictor-serving-cert
+      - name: ca-bundle
+        configMap:
+          name: openshift-service-ca.crt
+----
+<1> Replace `$NAMESPACE` with your target namespace
+<2> Use `local-completions` for OpenAI-compatible API endpoints
+<3> Model arguments configure the evaluation client
+<4> HTTPS endpoint of the OAuth-protected InferenceService
+<5> Path to mounted CA bundle for SSL verification
+<6> Service account token for OAuth authentication
+<7> Mount TLS certificate and CA bundle into container
+<8> Define volumes for TLS secret and CA bundle ConfigMap
+
+Apply the LMEvalJob:
+
+[source,bash]
+----
+kubectl apply -f tls-lmeval-job.yaml -n $NAMESPACE
+----
+
+== Configuration Reference
+
+=== TLS Certificate Paths
+
+[cols="1,2,1"]
+|===
+|Mount Path |Description |Source
+
+|`/etc/ssl/certs/tls.crt`
+|InferenceService TLS certificate
+|Secret `tls.crt` key
+
+|`/etc/ssl/certs/ca-bundle.crt`
+|Certificate Authority bundle
+|ConfigMap `service-ca.crt` key
+
+|`/etc/ssl/certs/tls.key`
+|Private key (if needed)
+|Secret `tls.key` key
+|===
+
+=== SSL Verification Options
+
+[cols="1,2,1"]
+|===
+|Value |Description |Use Case
+
+|`"False"`
+|Disable SSL verification (insecure)
+|Development only
+
+|`"/etc/ssl/certs/ca-bundle.crt"`
+|Use mounted CA bundle
+|Production with proper certificates
+
+|`"True"`
+|Use system default CA bundle
+|Standard SSL verification
+|===
+
+=== Volume Configuration Patterns
+
+==== TLS Secret Volume
+[source,yaml]
+----
+volumes:
+  - name: tls-certs
+    secret:
+      secretName: $MODEL-predictor-serving-cert
+      items:  # Optional: specify specific keys
+        - key: tls.crt
+          path: tls.crt
+        - key: tls.key
+          path: tls.key
+----
+
+==== CA Bundle ConfigMap Volume
+[source,yaml]
+----
+volumes:
+  - name: ca-bundle
+    configMap:
+      name: openshift-service-ca.crt
+      items:  # Optional: specify specific keys
+        - key: service-ca.crt
+          path: service-ca.crt
+----
+
+==== Volume Mount Options
+[source,yaml]
+----
+volumeMounts:
+  - name: tls-certs
+    mountPath: /etc/ssl/certs/tls.crt
+    subPath: tls.crt  # Mount specific file, not entire volume
+    readOnly: true
+  - name: ca-bundle
+    mountPath: /etc/ssl/certs/ca-bundle.crt
+    subPath: service-ca.crt
+    readOnly: true
+----
+
+== Verification and Troubleshooting
+
+=== Verify TLS Configuration
+
+Check that the LMEvalJob has proper TLS configuration:
+
+[source,bash]
+----
+kubectl get lmevaljob tls-eval-job -n $NAMESPACE -o yaml
+----
+
+Look for:
+
+- `verify_certificate: "/etc/ssl/certs/ca-bundle.crt"` in modelArgs
+- `volumeMounts` section in pod.container
+- `volumes` section in pod
+
+=== Check Pod Volume Mounts
+
+[source,bash]
+----
+kubectl describe pod tls-eval-job -n $NAMESPACE
+----
+
+Verify:
+
+- Volumes are listed in the pod spec
+- Volume mounts are correctly configured
+- No mount conflicts or permission issues
+
+=== Verify Certificate Access
+
+Check that certificates are accessible inside the pod:
+
+[source,bash]
+----
+kubectl exec tls-eval-job -n $NAMESPACE -- ls -la /etc/ssl/certs/
+kubectl exec tls-eval-job -n $NAMESPACE -- cat /etc/ssl/certs/ca-bundle.crt | head -5
+----
+
+=== Check SSL Warnings
+
+Monitor job logs for SSL-related messages:
+
+[source,bash]
+----
+kubectl logs tls-eval-job -n $NAMESPACE | grep -i ssl
+kubectl logs tls-eval-job -n $NAMESPACE | grep -i certificate
+kubectl logs tls-eval-job -n $NAMESPACE | grep -i verify
+----
+
+== Troubleshooting
+
+[cols="1,2,2"]
+|===
+|Problem |Causes |Solution
+
+|Certificate Not Found +
+*(File not found errors for certificate paths)*
+a|* Secret or configmap missing
+* Incorrect volume mount paths
+* Wrong secret/configmap names
+a|* Verify secret and configmap exist in the same namespace
+* Check volume mount paths and subPath values
+* Ensure correct secret/configmap names
+
+|SSL Verification Still Disabled +
+*(`InsecureRequestWarning` in logs, `verify_certificate: False` in modelArgs)*
+a|* Incorrect `verify_certificate` value in modelArgs
+* Certificate path not accessible
+* Wrong CA bundle content
+a|* Set `verify_certificate: "/etc/ssl/certs/ca-bundle.crt"`
+* Verify certificate files are mounted correctly
+* Check CA bundle contains valid certificates
+
+|Permission Denied +
+*(Permission errors accessing mounted certificates)*
+a|* Volume mount permissions
+* Secret and configmap access issues
+* Pod security context restrictions
+a|* Ensure volumes are mounted as `readOnly: true`
+* Check secret and configmap permissions
+* Verify pod security context if applicable
+
+|Certificate Trust Issues +
+*(SSL verification fails even with certificates mounted)*
+a|* Wrong CA bundle for the certificate chain
+* Certificate expired or invalid
+* Trust chain incomplete
+a|* Verify certificate validity: `openssl x509 -in /etc/ssl/certs/tls.crt -text -noout`
+* Check certificate chain matches CA bundle
+* Use correct ConfigMap for your cluster's CA
+|===


### PR DESCRIPTION
## Summary by Sourcery

Add new documentation pages for LMEval OAuth authentication and TLS certificate setup, and update the site navigation to include them.

Documentation:
- Add documentation for LMEval OAuth authentication
- Add documentation for LMEval TLS certificates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added two new tutorials to the site navigation: OAuth Authentication and TLS Certificates.
* Added a detailed TLS Certificates guide explaining TLS architecture, how to provide CA bundles and certificate mounts for LMEvalJob deployments, configuration options for SSL verification, example deployment configuration, verification steps, and troubleshooting tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->