### PR TITLE
fix broken link to ODH TrustyAI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the documentation for the TrustyAI project.
 
-A live version of the documentation is available at [https://trustyai-explainability.github.io](https://trustyai-explainability.github.io/trustyai-site/main/main.html).
+A live version of the documentation is available at [https://trustyai.org](https://trustyai.org).
 
 ## License
 

--- a/docs/modules/ROOT/pages/component-kserve-explainer.adoc
+++ b/docs/modules/ROOT/pages/component-kserve-explainer.adoc
@@ -2,7 +2,7 @@
 
 image::trustyai-kserve-explainer.svg[TrustyAI KServe architecture diagram]
 
-The TrustyAI KServe Explainer is a component that provides explanations for predictions made by using the built-in KServe explainer support footnote:fn-kserveexplainer[Documentation available at https://kserve.github.io/website/0.12/modelserving/explainer/explainer/[KServe explainers section].]. It supports xref:local-explainers.adoc#lime[LIME] and xref:local-explainers.adoc#shap[SHAP] explanation methods, configurable directly within KServe `InferenceServices`.
+The TrustyAI KServe Explainer is a component that provides explanations for predictions made by using the built-in KServe explainer support footnote:fn-kserveexplainer[Documentation available at https://kserve.github.io/website/docs/model-serving/predictive-inference/explainers/overview[KServe explainers section].]. It supports xref:local-explainers.adoc#lime[LIME] and xref:local-explainers.adoc#shap[SHAP] explanation methods, configurable directly within KServe `InferenceServices`.
 
 == Features
 

--- a/docs/modules/ROOT/pages/data-drift-monitoring.adoc
+++ b/docs/modules/ROOT/pages/data-drift-monitoring.adoc
@@ -108,8 +108,8 @@ include::example$model_gaussian_credit.yaml[]
 ----
 +
 . `data_tag`: A string tag to reference this particular set of data. Here, we choose `"TRAINING"`
-. `request`: A https://kserve.github.io/website/0.8/modelserving/inference_api/#inference-request-json-object[KServe Inference Request], as if you were sending this data directly to the model server's `/infer` endpoint. 
-. `response`: (Optionally) the https://kserve.github.io/website/0.8/modelserving/inference_api/#inference-response-json-objectt[KServe Inference Response] that is returned from sending the above request to the model.
+. `request`: A https://kserve.github.io/website/docs/concepts/architecture/data-plane[KServe Inference Request], as if you were sending this data directly to the model server's `/infer` endpoint.
+. `response`: (Optionally) the https://kserve.github.io/website/docs/concepts/architecture/data-plane[KServe Inference Response] that is returned from sending the above request to the model.
 
 == Examining TrustyAI's Model Metadata
 

--- a/docs/modules/ROOT/pages/main.adoc
+++ b/docs/modules/ROOT/pages/main.adoc
@@ -32,7 +32,7 @@ The Components tab in the side bar provides documentation for a number of Trusty
 - https://trustyai-explainability-python.readthedocs.io/en/latest/[TrustyAI Python Documentation]
 
 ### Tutorials
-- https://trustyai-explainability.github.io/trustyai-site/main/installing-opendatahub.html[The Tutorials sidebar tab] provides walkthroughs of a variety of different TrustyAI flows, like bias monitoring, drift monitoring, and language model evaluation.
+- https://opendatahub.io/docs/monitoring-your-ai-systems/#configuring-trustyai_monitor[Monitor your AI systems via TrustyAI] provides walkthroughs of a variety of different TrustyAI flows, like bias monitoring, drift monitoring, and language model evaluation.
 - https://github.com/trustyai-explainability/trustyai-explainability-python-examples[trustyai-explainability-python-examples]: Examples on how to get started with the Python TrustyAI library.
 - https://github.com/trustyai-explainability/odh-trustyai-demos[trustyai-odh-demos]: Demos of the TrustyAI Service within Open Data Hub.
 

--- a/docs/modules/ROOT/pages/main.adoc
+++ b/docs/modules/ROOT/pages/main.adoc
@@ -2,7 +2,7 @@
 
 image::trustyai-logo-wide.svg[Static,300]
 
-https://trustyai-explainability.github.io/trustyai-site/main/main.html[TrustyAI] is an open source Responsible AI toolkit supported by Red Hat and IBM. TrustyAI provides tools for a variety of responsible AI workflows, such as:
+https://trustyai.org[TrustyAI] is an open source Responsible AI toolkit supported by Red Hat and IBM. TrustyAI provides tools for a variety of responsible AI workflows, such as:
 
 * Local and global model explanations
 * Fairness metrics

--- a/docs/modules/ROOT/pages/main.adoc
+++ b/docs/modules/ROOT/pages/main.adoc
@@ -28,7 +28,7 @@ TrustyAI is a default component of https://opendatahub.io/[Open Data Hub] and ht
 ### Documentation
 The Components tab in the side bar provides documentation for a number of TrustyAI components. Also check out:
 
-- https://opendatahub.io/docs/monitoring-data-science-models/#configuring-trustyai_monitor[Open Data Hub Documentation]
+- https://opendatahub.io/docs/getting-started-with-open-data-hub/[Open Data Hub Documentation]
 - https://trustyai-explainability-python.readthedocs.io/en/latest/[TrustyAI Python Documentation]
 
 ### Tutorials

--- a/docs/modules/ROOT/pages/saliency-explanations-with-kserve.adoc
+++ b/docs/modules/ROOT/pages/saliency-explanations-with-kserve.adoc
@@ -5,7 +5,7 @@ This tutorial will walk you through setting up and using TrustyAI to provide sal
 
 == Prerequisites
 - An operational Kubernetes cluster.
-- KServe 0.11 installed on the cluster. footnote:fn-kserveinstallation[You can find the installation instructions here: https://kserve.github.io/website/0.11/admin/serverless/serverless/[KServe Installation Guide].]
+- KServe 0.11 installed on the cluster. footnote:fn-kserveinstallation[You can find the installation instructions here: https://kserve.github.io/website/docs/admin-guide/serverless[KServe Installation Guide].]
 - The `kubectl` command-line tool installed.
 
 == Setup
@@ -72,7 +72,7 @@ You will see that in addition to the `predictor` pod, there is also an `explaine
 == Making predictions
 
 Predictions are performed in the same way as with regular `InferenceService` deployments. We can use the `kubectl` command to send a request to the model.
-We leave the access mode to the `InferenceService` to the user's discretion, depending on the Kubernetes cluster configuration. Some possible options are available in the https://kserve.github.io/website/0.11/get_started/first_isvc/[KServe documentation]. For the rest of this tutorial, we will use port-forwarding to access the service, for simplicity and assume local access.
+We leave the access mode to the `InferenceService` to the user's discretion, depending on the Kubernetes cluster configuration. Some possible options are available in the https://kserve.github.io/website/docs/getting-started/predictive-first-isvc[KServe documentation]. For the rest of this tutorial, we will use port-forwarding to access the service, for simplicity and assume local access.
 
 We will use the following payload to make a prediction, which we know from the test data will produce a positive prediction. The payload is available for download xref:attachment$kserve-explainer-payload.json[here].
 


### PR DESCRIPTION
Replace the broken trustyai-site link with the correct Open Data Hub documentation URL for TrustyAI monitoring. Also update the link text to better describe the content.

## Summary by Sourcery

Documentation:
- Fix the TrustyAI monitoring link in the main docs to point to the correct Open Data Hub documentation and clarify its label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TrustyAI documentation links to point to the current official site.
  * Replaced previous tutorial link with the Open Data Hub TrustyAI monitoring tutorial.
  * Updated KServe-related guidance links to current installation and explainer pages.
  * Added a new data_tag field to the Data Upload Payload documentation and fixed related payload link references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->